### PR TITLE
list all macros, remove cmd prefix if present

### DIFF
--- a/src/main/java/me/ping/bot/Bot.java
+++ b/src/main/java/me/ping/bot/Bot.java
@@ -13,20 +13,12 @@ import net.dv8tion.jda.api.JDABuilder;
 
 import javax.crypto.Mac;
 
-// TODO: get Settings.getInstance() in all listener classes
-// TODO: replace hard coded prefix (-) with settings.getCmdPrefix()
 public class Bot {
     public static void main(String[] args) throws Exception {
         Bot bot = new Bot();
         JDA jda = bot.prepareJDA();
         bot.prepareDatabase();
         new Heartbeat(jda);
-//        Settings s = Settings.getInstance();
-//        s.loadSettings();
-//        System.out.println(s.getCmdPrefix());
-//        System.out.println(s.getCmdPrefixSeparator());
-//        System.out.println(s.getEmbedColor());
-//        System.out.println(s.getRoleIdsAsString());
     }
 
     private JDA prepareJDA() {

--- a/src/main/java/me/ping/bot/commands/elevated/ElevatedListener.java
+++ b/src/main/java/me/ping/bot/commands/elevated/ElevatedListener.java
@@ -79,6 +79,9 @@ public class ElevatedListener extends ListenerAdapter {
             if (StringUtils.hasCommand(prefix + "editmacro", msg, true)) {
                 macroCmd.editMacro(event);
             }
+            if (StringUtils.hasCommand(prefix + "macros", msg, false)) {
+                macroCmd.listAllMacros(event);
+            }
         }
     }
 


### PR DESCRIPTION
- added a `macros` command to list all macros
-  check for cmd prefix on add/remove/editmacro commands and remove if its present